### PR TITLE
Issue: #16 removes deprecation warning for Python 3.11

### DIFF
--- a/impl/python/anyascii/__init__.py
+++ b/impl/python/anyascii/__init__.py
@@ -4,9 +4,15 @@ from sys import intern
 from zlib import decompress, MAX_WBITS
 
 try:
-    from importlib.resources import read_binary
+    from importlib.resources import files
+
+    def read_binary(package, resource):
+        return files(package).joinpath(resource).read_bytes()
 except ImportError:
-    from pkgutil import get_data as read_binary
+    try:
+        from importlib.resources import read_binary
+    except ImportError:
+        from pkgutil import get_data as read_binary
 
 __version__ = '0.3.2.dev0'
 


### PR DESCRIPTION
This should be backwards compatible with existing solutions and forward compatible with later versions of Python.

https://docs.python.org/3/library/importlib.resources.html#importlib.resources.read_binary

Resolves issue #16 